### PR TITLE
2234 - add Step Start Time to report template

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "settings"]
+	path = settings
+	url = https://github.com/Proemion/settings.git

--- a/lib/generate-report.js
+++ b/lib/generate-report.js
@@ -65,6 +65,7 @@ function generateReport(options) {
   const saveCollectedJSON = !!options.saveCollectedJSON;
   const displayDuration = !!options.displayDuration;
   const displayReportTime = !!options.displayReportTime;
+  const displayStepStartTime = !!options.displayStepStartTime;
   const durationInMS = !!options.durationInMS;
   const hideMetadata = !!options.hideMetadata;
   const pageTitle = options.pageTitle || 'Multiple Cucumber HTML Reporter';
@@ -87,6 +88,7 @@ function generateReport(options) {
     hideMetadata: hideMetadata,
     displayReportTime: displayReportTime,
     displayDuration: displayDuration,
+    displayStepStartTime: displayStepStartTime,
     browser: 0,
     name: '',
     version: 'version',
@@ -475,6 +477,10 @@ function generateReport(options) {
           step.result.status !== RESULT_STATUS.failed)
       ) {
         return 0;
+      }
+
+      if (step.result.startTime) {
+        step.startTime = step.result.startTime;
       }
 
       if (step.result.duration) {

--- a/templates/components/scenarios.tmpl
+++ b/templates/components/scenarios.tmpl
@@ -130,6 +130,14 @@
                                         <% } %>
                                     <% } %>
 
+                                    <% if(suite.displayStepStartTime) { %>
+                                        <% if (step.startTime) { %>
+                                            <span class="startTime"><%= step.startTime %></span>
+                                        <% } else { %>
+                                            <span class="startTime">00:00:00.000</span>
+                                        <% } %>
+                                    <% } %>
+
                                 </div>
 
                                 <% if(step.result) { %>

--- a/test/test.js
+++ b/test/test.js
@@ -4,8 +4,31 @@ const path = require('node:path');
 const test = require('../lib/generate-report');
 
 /**
- * Generate a report for browsers
+ * Generate a report for proemion input
  */
+test.generate({
+    saveCollectedJSON: true,
+    jsonDir: './test/unit/data/proemion/',
+    reportPath: './.tmp/proemion/',
+    reportName: 'You can adjust this report name',
+    overrideStyle: path.join(__dirname, './proemion.css'),
+    customMetadata: true,
+    displayDuration: true,
+    displayStepStartTime: true,
+    plainDescription: true,
+    customData: {
+        title: 'Run info',
+        data: [
+            {label: 'Project', value: 'Custom embedded project'},
+            {label: 'Release', value: '4.5.6'},
+        ]
+    }
+});
+
+/*
+/!**
+ * Generate a report for browsers
+ *!/
 test.generate({
     saveCollectedJSON: true,
     jsonDir: './test/unit/data/json/',
@@ -26,9 +49,9 @@ test.generate({
     }
 });
 
-/**
+/!**
  * Generate a report with array of embedded data
- */
+ *!/
 test.generate({
     saveCollectedJSON: true,
     jsonDir: './test/unit/data/embedded-array-json/',
@@ -48,9 +71,9 @@ test.generate({
     }
 });
 
-/**
+/!**
  * Generate a report for browsers with report time
- */
+ *!/
 test.generate({
     saveCollectedJSON: true,
     jsonDir: './test/unit/data/json/',
@@ -73,10 +96,10 @@ test.generate({
     }
 });
 
-/**
+/!**
  * Generate a report with custom metadata
  * NOTE: must be last, if you use customMetadata you cannot reuse generator
- */
+ *!/
 test.generate({
     saveCollectedJSON: true,
     jsonDir: './test/unit/data/custom-metadata-json/',
@@ -91,3 +114,4 @@ test.generate({
         { "name": "platform version", "value": "16.04" }
     ]
 });
+*/

--- a/test/test.js
+++ b/test/test.js
@@ -25,10 +25,9 @@ test.generate({
     }
 });
 
-/*
-/!**
+/**
  * Generate a report for browsers
- *!/
+ */
 test.generate({
     saveCollectedJSON: true,
     jsonDir: './test/unit/data/json/',
@@ -49,9 +48,9 @@ test.generate({
     }
 });
 
-/!**
+/**
  * Generate a report with array of embedded data
- *!/
+ */
 test.generate({
     saveCollectedJSON: true,
     jsonDir: './test/unit/data/embedded-array-json/',
@@ -71,9 +70,9 @@ test.generate({
     }
 });
 
-/!**
+/**
  * Generate a report for browsers with report time
- *!/
+ */
 test.generate({
     saveCollectedJSON: true,
     jsonDir: './test/unit/data/json/',
@@ -96,10 +95,10 @@ test.generate({
     }
 });
 
-/!**
+/**
  * Generate a report with custom metadata
  * NOTE: must be last, if you use customMetadata you cannot reuse generator
- *!/
+ */
 test.generate({
     saveCollectedJSON: true,
     jsonDir: './test/unit/data/custom-metadata-json/',
@@ -114,4 +113,3 @@ test.generate({
         { "name": "platform version", "value": "16.04" }
     ]
 });
-*/


### PR DESCRIPTION
This PR contains changes of the html reporter to make it possible to display Step Start Time in the generated HTML report.

Fixes: https://github.com/Proemion/canlink-test-suite/issues/2234
Related: https://github.com/Proemion/canlink-test-suite/pull/2338

A new attribute was added to set if the display of this parameter is enabled or not:

```
displayStepStartTime: displayStepStartTime,
```

Check if the `report.json` contains the key-value of startTime of the steps. If yes, store it and if the it's visualization is enabled display it.

```
if (step.result.startTime) {
   step.startTime = step.result.startTime;
}
```

Also, the scenario.tmpl was modified in order to display the step start time value.

```
 <% if(suite.displayStepStartTime) { %>
      <% if (step.startTime) { %>
            <span class="startTime"><%= step.startTime %></span>
      <% } else { %>
                 <span class="startTime">00:00:00.000</span>
              <% } %>
<% } %>
```
